### PR TITLE
Resampling: support different coverage for target and source

### DIFF
--- a/test/test_resample_with_transforms.py
+++ b/test/test_resample_with_transforms.py
@@ -1,0 +1,69 @@
+import numpy as np
+import pytest
+import gridtools.resampling as gtr
+
+
+SRC = np.array(
+    [
+        [0.9, 0.5, 3.0, 4.0],
+        [1.1, 1.5, 1.0, 2.0],
+        [4.0, 2.1, 3.0, 5.0],
+        [3.0, 4.9, 3.0, 1.0],
+    ]
+)
+
+SRC_TRANSFORM = (1.0, 0.0, 0.0, 0.0, -1.0, 4.0)
+OUT_TRANSFORM = (1.0, 0.0, 0.5, 0.0, -1.0, 3.5)
+
+
+def test_downsample_2d_first():
+    assert np.array_equal(
+        gtr.downsample_2d(SRC, 2, 2, gtr.DS_FIRST, src_transform=SRC_TRANSFORM, out_transform=OUT_TRANSFORM),
+        np.array([
+            [0.9, 0.5],
+            [1.1, 1.5],
+        ])
+    )
+
+
+def test_downsample_2d_mean():
+    assert np.array_equal(
+        gtr.downsample_2d(SRC, 2, 2, gtr.DS_MEAN, src_transform=SRC_TRANSFORM, out_transform=OUT_TRANSFORM),
+        np.array([
+            [(0.9 + 0.5 + 1.1 + 1.5) / 4.0, (0.5 + 3.0 + 1.5 + 1.0) / 4.0],
+            [(1.1 + 1.5 + 4.0 + 2.1) / 4.0, (1.5 + 1.0 + 2.1 + 3.0) / 4.0],
+        ])
+    )
+
+
+def test_downsample_2d_mean_positive_dy():
+    src_transform = (1.0, 0.0, 0.0, 0.0, 1.0, -4.0)
+    out_transform = (1.0, 0.0, 0.5, 0.0, 1.0, -3.5)
+    assert np.array_equal(
+        gtr.downsample_2d(SRC, 2, 2, gtr.DS_MEAN, src_transform=src_transform, out_transform=out_transform),
+        np.array([
+            [(0.9 + 0.5 + 1.1 + 1.5) / 4.0, (0.5 + 3.0 + 1.5 + 1.0) / 4.0],
+            [(1.1 + 1.5 + 4.0 + 2.1) / 4.0, (1.5 + 1.0 + 2.1 + 3.0) / 4.0],
+        ])
+    )
+
+
+def test_errors():
+    with pytest.raises(ValueError): # only one transform
+        gtr.downsample_2d(SRC, 2, 2, gtr.DS_MEAN, src_transform=SRC_TRANSFORM)
+    with pytest.raises(ValueError): # source has larger grid cells than out
+        src_transform = (2.0, 0.0, 0.0, 0.0, -2.0, 4.0)
+        gtr.downsample_2d(SRC, 2, 2, gtr.DS_MEAN, src_transform=src_transform, out_transform=OUT_TRANSFORM)
+    with pytest.raises(NotImplementedError): # rotated grid
+        src_transform = (1.0, 45.0, 0.0, 0.0, -1.0, 4.0)
+        gtr.downsample_2d(SRC, 2, 2, gtr.DS_MEAN, src_transform=src_transform, out_transform=OUT_TRANSFORM)
+    with pytest.raises(ValueError): # negative pixel width, source only
+        src_transform = (-1.0, 0.0, 0.0, 0.0, -1.0, 4.0)
+        gtr.downsample_2d(SRC, 2, 2, gtr.DS_MEAN, src_transform=src_transform, out_transform=OUT_TRANSFORM)
+    with pytest.raises(ValueError): # positive pixel width, source only
+        src_transform = (1.0, 0.0, 0.0, 0.0, 1.0, 4.0)
+        gtr.downsample_2d(SRC, 2, 2, gtr.DS_MEAN, src_transform=src_transform, out_transform=OUT_TRANSFORM)
+    with pytest.raises(ValueError): # out x falls outside of source
+        gtr.downsample_2d(SRC, 4, 2, gtr.DS_MEAN, src_transform=SRC_TRANSFORM)
+    with pytest.raises(ValueError): # out y falls outside of source
+        gtr.downsample_2d(SRC, 2, 4, gtr.DS_MEAN, src_transform=SRC_TRANSFORM)


### PR DESCRIPTION
Hello everyone,

I have a need to resample (xarray) grids, and through [this thread](https://github.com/pydata/xarray/issues/486) found this neat package, which does most of what I need!

However, for my use case, the source and target grids don't line up exactly most of the time. So I had a look through the source, and it seemed fairly straightforward to implement, by offsetting the x and y based on the origins of the source and target grids. They just need some spatial reference information.

I've chosen to represent that information via an Affine transform, since it's consistent with [rasterio](https://github.com/mapbox/rasterio), while not super intuitive, [at least it's "correct"](https://www.perrygeo.com/python-affine-transforms.html)  from an algebra point of view. This also matches nicely with the `transform` metadata that `xarray.open_rasterio()` returns. 

It looks like you already had a very similar idea with the [geocs](https://github.com/esa-esdl/gridtools/tree/geocs)? I've gone ahead to send this pull request since I feel it's easier to discuss that way. (For example, it really needs a few more tests.)

It should also work for both positive and negative dx and/or dy, provided they have the same sign in the source and target.

For now, I've implemented it just for the downsampling, since I still have a question regarding the upsampling that I'll post in the issues shortly.