### PR TITLE
Downsampling: JIT'ed function for aggregation

### DIFF
--- a/gridtools/resampling.py
+++ b/gridtools/resampling.py
@@ -3,6 +3,7 @@ from __future__ import division
 
 import numpy as np
 from numba import jit
+from numba.targets.registry import CPUDispatcher
 
 #: Interpolation method for upsampling: Take nearest source grid cell, even if it is invalid.
 US_NEAREST = 10
@@ -129,9 +130,8 @@ def downsample_2d(src, w, h, method=DS_MEAN, fill_value=None, mode_rank=1, out=N
         return src
     mask, use_mask = _get_mask(src)
     fill_value = _get_fill_value(fill_value, src, out)
-    if callable(method):
-        func = jit(method, nopython=True)
-        return _mask_or_not(_downsample_2d_func(src, mask, use_mask, func, fill_value, out), src, fill_value)
+    if isinstance(method, CPUDispatcher):
+        return _mask_or_not(_downsample_2d_func(src, mask, use_mask, method, fill_value, out), src, fill_value)
     else:
         return _mask_or_not(_downsample_2d(src, mask, use_mask, method, fill_value, mode_rank, out), src, fill_value)
 

--- a/gridtools/resampling.py
+++ b/gridtools/resampling.py
@@ -129,7 +129,11 @@ def downsample_2d(src, w, h, method=DS_MEAN, fill_value=None, mode_rank=1, out=N
         return src
     mask, use_mask = _get_mask(src)
     fill_value = _get_fill_value(fill_value, src, out)
-    return _mask_or_not(_downsample_2d(src, mask, use_mask, method, fill_value, mode_rank, out), src, fill_value)
+    if callable(method):
+        func = jit(method, nopython=True)
+        return _mask_or_not(_downsample_2d_func(src, mask, use_mask, func, fill_value, out), src, fill_value)
+    else:
+        return _mask_or_not(_downsample_2d(src, mask, use_mask, method, fill_value, mode_rank, out), src, fill_value)
 
 
 def _get_out(out, src, shape):
@@ -503,4 +507,68 @@ def _downsample_2d(src, mask, use_mask, method, fill_value, mode_rank, out):
     else:
         raise ValueError('invalid upsampling method')
 
+    return out
+
+
+@jit(nopython=True)
+def _downsample_2d_func(src, mask, use_mask, func, fill_value, out):
+    # np.zeros is as default necessary for numba, it tries to unpack src_transform and out_transform
+    src_w = src.shape[-1]
+    src_h = src.shape[-2]
+    out_w = out.shape[-1]
+    out_h = out.shape[-2]
+
+    if src_w == out_w and src_h == out_h:
+        return src
+
+    if out_w > src_w or out_h > src_h:
+        raise ValueError("invalid target size")
+
+    scale_x = src_w / out_w
+    scale_y = src_h / out_h
+
+    max_value_count = int(scale_x + 1) * int(scale_y + 1)
+    values = np.zeros((max_value_count,), dtype=src.dtype)
+    weights = np.zeros((max_value_count,), dtype=src.dtype)
+    for out_y in range(out_h):
+        src_yf0 = scale_y * out_y
+        src_yf1 = src_yf0 + scale_y
+        src_y0 = int(src_yf0)
+        src_y1 = int(src_yf1)
+        wy0 = 1.0 - (src_yf0 - src_y0)
+        wy1 = src_yf1 - src_y1
+        if wy1 < _EPS:
+            wy1 = 1.0
+            if src_y1 > src_y0:
+                src_y1 -= 1
+        for out_x in range(out_w):
+            src_xf0 = scale_x * out_x
+            src_xf1 = src_xf0 + scale_x
+            src_x0 = int(src_xf0)
+            src_x1 = int(src_xf1)
+            wx0 = 1.0 - (src_xf0 - src_x0)
+            wx1 = src_xf1 - src_x1
+            if wx1 < _EPS:
+                wx1 = 1.0
+                if src_x1 > src_x0:
+                    src_x1 -= 1
+            w_sum = 0.0
+            count = 0
+            for src_y in range(src_y0, src_y1 + 1):
+                wy = wy0 if (src_y == src_y0) else wy1 if (src_y == src_y1) else 1.0
+                for src_x in range(src_x0, src_x1 + 1):
+                    wx = wx0 if (src_x == src_x0) else wx1 if (src_x == src_x1) else 1.0
+                    v = src[src_y, src_x]
+                    if np.isfinite(v) and not (use_mask and mask[src_y, src_x]):
+                        w = wx * wy
+                        weights[count] = w
+                        values[count] = v
+                        w_sum += w
+                        count += 1
+            if w_sum < _EPS:
+                out[out_y, out_x] = fill_value
+            else:
+                out[out_y, out_x] = func(values, weights)
+            weights[:] = 0
+            values[:] = 0
     return out

--- a/test/test_downsample_2d.py
+++ b/test/test_downsample_2d.py
@@ -181,3 +181,39 @@ class Downsample2dTest(unittest.TestCase):
                                  2, 2, gtr.DS_STD, -1,
                                  [[0.36055513, 1.24721913],
                                   [0., 0.82192187]])
+
+
+SRC = np.array(
+    [
+        [0.6, 0.2, 3.4],
+        [1.4, 1.6, 1.0],
+        [4.0, 2.8, 3.0],
+    ]
+)
+
+def test_downsample_2d_with_functions():
+    def p50(values, weights):
+        values = values[weights > 0]
+        return  np.percentile(values, 50)
+
+    assert np.array_equal(gtr.downsample_2d(SRC, 2, 2, method=p50),
+        np.array([[1.0, 1.3], [2.2, 2.2]]))
+
+    def harmonic_mean(values, weights):
+        s = values.size
+        v_agg = 0.0
+        w_sum = 0.0
+        for i in range(s):
+            w = weights[i]
+            if w > 0:
+                w_sum += w
+                v_agg += w / values[i]
+        return w_sum / v_agg
+    
+    assert np.array_equal(gtr.downsample_2d(SRC, 2, 2, method=harmonic_mean),
+        np.array(
+            [
+                [2.25 / (1 / 0.6 + 0.5 / 0.2 + 0.5 / 1.4 + 0.25 / 1.6), 2.25 / (1 / 3.4 + 0.5 / 0.2 + 0.5 / 1.0 + 0.25 / 1.6)],
+                [2.25 / (1 / 4.0 + 0.5 / 2.8 + 0.5 / 1.4 + 0.25 / 1.6), 2.25 / (1 / 3.0 + 0.5 / 2.8 + 0.5 / 1.0 + 0.25 / 1.6)]]
+        )
+    )

--- a/test/test_downsample_2d.py
+++ b/test/test_downsample_2d.py
@@ -1,7 +1,7 @@
 import unittest
 
 import numpy as np
-
+from numba import jit
 import gridtools.resampling as gtr
 
 NAN = np.nan
@@ -192,6 +192,7 @@ SRC = np.array(
 )
 
 def test_downsample_2d_with_functions():
+    @jit(nopython=True)
     def p50(values, weights):
         values = values[weights > 0]
         return  np.percentile(values, 50)
@@ -199,6 +200,7 @@ def test_downsample_2d_with_functions():
     assert np.array_equal(gtr.downsample_2d(SRC, 2, 2, method=p50),
         np.array([[1.0, 1.3], [2.2, 2.2]]))
 
+    @jit(nopython=True)
     def harmonic_mean(values, weights):
         s = values.size
         v_agg = 0.0


### PR DESCRIPTION
Many of the downsampling aggregation methods essentially take as arguments an array of weights, and an array of values. Abstracting this allows for a lot of flexibility in quickly specifiying aggregation methods, provided numba can JIT them. I've added a function in resampling.py, called _resample_2d_func, which takes a JIT'ed function rather than a method as argument.

This makes life a lot easier for me, as I can specify functions on the fly if I want to use another aggregation method. For example, my colleagues and I often use percentile aggregation, or harmonic means (we're working with conductivities):
```Python
@jit(nopython=True)
def p50(values, weights):
    values = values[weights > 0]
    return np.percentile(values, 50)

result = gtr.downsample_2d(SRC, 2, 2, method=p50)
```
```Python
@jit(nopython=True)
def harmonic_mean(values, weights):
    s = values.size
    v_agg = 0.0
    w_sum = 0.0
    for i in range(s):
        w = weights[i]
        if w > 0:
            w_sum += w
            v_agg += w / values[i]
    return w_sum / v_agg
    
result = gtr.downsample_2d(SRC, 2, 2, method=harmonic_mean)
```

Of course, there's a bit of overhead compared to the direct implementation:
```Python
import gridtools.resampling as gtr
import numpy as np
from numba import jit

@jit(nopython=True)
def mean(values, weights):
    s = values.size
    v_sum = 0.0
    w_sum = 0.0
    for i in range(s):
        w = weights[i]
        if w > 0:
            w_sum += w
            v_sum += values[i] * w
    return v_sum / w_sum

SRC = np.arange(1.0e6).reshape(1000, 1000)
```

```Python
%timeit gtr.downsample_2d(SRC, 100, 100, gtr.DS_MEAN)
3.3 ms ± 174 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

```Python
%timeit gtr.downsample_2d(SRC, 100, 100, mean)
5.73 ms ± 183 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

I'm curious to hear what you think!